### PR TITLE
Fix dependency declaration for mip

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
       ["ucertpin.py", "github:mkomon/ucertpin/lib/ucertpin.py"]
     ],
     "deps": [
-      ["github:mkomon/uasn1"]
+      ["github:mkomon/uasn1", "master"]
     ],
     "version": "0.1"
 }


### PR DESCRIPTION
micropython mip expects the a package.json to also provide a branch or tag name for each dependency. Add the "master" branch stanza.